### PR TITLE
Fix a couple of issues setting type attribute in IE8.

### DIFF
--- a/packages/ember-htmlbars/tests/integration/component_ie8_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_ie8_test.js
@@ -1,0 +1,61 @@
+import ComponentLookup from "ember-views/component_lookup";
+import Component from "ember-views/views/component";
+import EmberView from "ember-views/views/view";
+import Registry from "container/registry";
+import compile from "ember-template-compiler/system/compile";
+import { runAppend, runDestroy } from "ember-runtime/tests/utils";
+
+var view, registry, container;
+
+QUnit.module("ember-htmlbars: component - dynamic type in IE8 safe environment", {
+  setup() {
+    registry = new Registry();
+    container = registry.container();
+    registry.optionsForType('component', { singleton: false });
+    registry.optionsForType('view', { singleton: false });
+    registry.optionsForType('template', { instantiate: false });
+    registry.register('component-lookup:main', ComponentLookup);
+  },
+
+  teardown() {
+    runDestroy(container);
+    runDestroy(view);
+    registry = container = view = null;
+  }
+});
+
+QUnit.test("set type attribute in IE8 from template", function() {
+  registry.register('component:x-foo', Component.extend({
+    tagName: 'input',
+    type: 'text',
+    attributeBindings: ['type']
+  }));
+
+  view = EmberView.create({
+    container: container,
+    template: compile('{{x-foo type="email" ie8SafeInput=true}}')
+  });
+
+  runAppend(view);
+
+  var type = view.$('input').attr('type');
+  equal(type, 'email', 'Type was set to expected "email".');
+});
+
+QUnit.test("set type attribute in IE8 from component definition", function() {
+  registry.register('component:x-foo', Component.extend({
+    tagName: 'input',
+    type: 'radio',
+    attributeBindings: ['type']
+  }));
+
+  view = EmberView.create({
+    container: container,
+    template: compile('{{x-foo ie8SafeInput=true}}')
+  });
+
+  runAppend(view);
+
+  var type = view.$('input').attr('type');
+  equal(type, 'radio', 'Type was set to expected "radio".');
+});

--- a/packages/ember-views/lib/system/build-component-template.js
+++ b/packages/ember-views/lib/system/build-component-template.js
@@ -217,14 +217,18 @@ function normalizeComponentAttributes(component, isAngleBracket, attrs, canChang
   // being appended, and unbind type.
   if (normalized.type && !canChangeType) {
     if (normalized.type[0] === 'get') {
+      // Handle case when type is a bound attribute but has no attribute value
+      // specified in the component template. Look up the default value in the
+      // component.
       Ember.warn(`Bound type attr on input. In IE8 this attribute will not be updated after initial render. https://github.com/tildeio/htmlbars/issues/380.`);
       var type = normalized.type[1];
       var periodIndex = type.indexOf(".");
       var property = type.substring(periodIndex + 1);
-
-      normalized.type = component.parentView.get(property);
-    } else if (normalized.type[0] === 'value' && typeof(normalized.type[1] !== 'string')) {
-      Ember.warn(`Bound type attr on input. In IE8 this attribute will not be updated after initial render. https://github.com/tildeio/htmlbars/issues/380.`);
+      normalized.type = component.get(property);
+    } else if (normalized.type[0] === 'value' && typeof normalized.type[1] !== 'string') {
+      // Handle case where a non-string value is passed as an attribute in the
+      // component template. Fall back to the default value in the component.
+      Ember.warn(`Invalid type attr on input. In IE8 this attribute will not be updated after initial render. https://github.com/tildeio/htmlbars/issues/380.`);
       normalized.type = component.get('type');
     } else {
       normalized.type = normalized.type[1];


### PR DESCRIPTION
1. Fix using default type attribute defined in component. Load type value from component, not parent view.
2. Fix operator precidence syntax on typeof check for template attribute value.
3. Add more tests.
